### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Potential fix for [https://github.com/AStrasler/AaronStrasler/security/code-scanning/1](https://github.com/AStrasler/AaronStrasler/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/codeql.yml` so the workflow limits `GITHUB_TOKEN` privileges.

Best fix here: define permissions at the workflow root (applies to all jobs unless overridden) with least privilege required for this workflow. At minimum, set:
- `contents: read`

Given this is a CodeQL workflow that analyzes pull requests, it is also common to include:
- `security-events: write` (to upload SARIF/code scanning results)
- `actions: read` (safe/read-only for action metadata access)

Change region: directly under the `on:` trigger block and before `jobs:` in `.github/workflows/codeql.yml`. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
